### PR TITLE
Add an extra space to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
 
 ### 介绍
 
-实现了基于tranformer xl进行文本生成任务，代码基于https://github.com/kimiyoung/transformer-xl。  也从这里看起，有基本了解，感谢他们的工作。主要改动在下面几个地方：
+实现了基于tranformer xl进行文本生成任务，代码基于https://github.com/kimiyoung/transformer-xl 。  也从这里看起，有基本了解，感谢他们的工作。主要改动在下面几个地方：
 
 + 原本的代码只有training 和 eval，增加了inference 部分，主要在train_gpu中增加了inference 函数以及相应函数的改变。
 + 增加了可视化每一层attention以及查看每个结果候选词的代码，在visualize_attention.py中。


### PR DESCRIPTION
markdown的渲染让这个超链接里面多了个句号，导致无法点开。要加一个空格分开他们